### PR TITLE
Cannot use admin interface for collection which were created without migrate command.

### DIFF
--- a/djongo/sql2mongo/query.py
+++ b/djongo/sql2mongo/query.py
@@ -415,6 +415,18 @@ class InsertQuery(VoidQuery):
             return_document=ReturnDocument.AFTER
         )
 
+        if not auto:
+            doc = self.db_ref['__schema__'].insert_one(
+                {
+                    'name': self.left_table,
+                    'auto': {
+                        'seq': 1,
+                        'field_names': ['id']
+                    }
+                }
+            )
+            auto = self.db_ref['__schema__'].find_one(doc.inserted_id)
+        
         for i, val in enumerate(self._vals):
             ins = {}
             if auto:


### PR DESCRIPTION
If 'ENFORCE_SCHEMA' == False, any collection (without migrate command) is created without "id" (auto) field what makes admin interface unusable for the collection.
This patch creates "id" field in any case for every collection.